### PR TITLE
Remove vbv-maxrate configuration

### DIFF
--- a/assets/h264CPU.conf
+++ b/assets/h264CPU.conf
@@ -17,5 +17,4 @@ system_priority=2
 
 # x264 by default
 hevc_mode=0
-vbv_maxrate=30000
 vbv_bufsize=1000

--- a/assets/h265CPU.conf
+++ b/assets/h265CPU.conf
@@ -17,5 +17,4 @@ system_priority=2
 
 # x265 by default
 hevc_mode=2
-vbv_maxrate=20000
 vbv_bufsize=1000

--- a/assets/sunshine.conf
+++ b/assets/sunshine.conf
@@ -28,6 +28,5 @@ system_priority=1
 
 # x265 by default
 hevc_mode=2
-vbv_maxrate=1500
 vbv_bufsize=3000
 

--- a/openstreamapp/ConfigurationDialog.cpp
+++ b/openstreamapp/ConfigurationDialog.cpp
@@ -137,11 +137,6 @@ ConfigurationDialog::ConfigurationDialog(QWidget *parent)
     configInputForm->addRow(POOLS_LABEL, poolsFieldLineEdit);
 
     /*******Encoder params****************/
-    x265vbvMaxRateFieldLineEdit = new QLineEdit(this);
-    x265vbvMaxRateFieldLineEdit->setText(config->getKey(QString("vbv_maxrate")));
-    entries_snapshot.insert("vbv_maxrate", config->getKey(QString("vbv_maxrate")));
-    configInputForm->addRow(x265vbvMaxRate_LABEL, x265vbvMaxRateFieldLineEdit);
-
     x265vbvBufsizeFieldLineEdit = new QLineEdit(this);
     x265vbvBufsizeFieldLineEdit->setText(config->getKey(QString("vbv_bufsize")));
     entries_snapshot.insert("vbv_bufsize", config->getKey(QString("vbv_bufsize")));
@@ -234,8 +229,6 @@ void ConfigurationDialog::updateNewConfiguration()
 
 
     /***************ENCODEr params***************/
-    QString x265vbvMaxRate = x265vbvMaxRateFieldLineEdit->text();
-    config->setEntry("vbv_maxrate", x265vbvMaxRate);
     QString x265vbvBufsize = x265vbvBufsizeFieldLineEdit->text();
     config->setEntry("vbv_bufsize", x265vbvBufsize);
     QString crf = crfLineEdit->text();
@@ -258,7 +251,6 @@ void ConfigurationDialog::updateNewConfiguration()
         || entries_snapshot.value("hevc_mode") != config->getKey("hevc_mode")
         || entries_snapshot.value("min_threads") != config->getKey("min_threads")
         || entries_snapshot.value("system_priority") != config->getKey("system_priority")
-        || entries_snapshot.value("vbv_maxrate") != config->getKey("vbv_maxrate")
         || entries_snapshot.value("vbv_bufsize") != config->getKey("vbv_bufsize")
         || entries_snapshot.value("crf") != config->getKey("crf")
         || entries_snapshot.value("pools") != config->getKey("pools")
@@ -270,7 +262,6 @@ void ConfigurationDialog::updateNewConfiguration()
         entries_snapshot.insert("hevc_mode", config->getKey("hevc_mode"));
         entries_snapshot.insert("min_threads",config->getKey("min_threads"));
         entries_snapshot.insert("system_priority", config->getKey("system_priority"));
-        entries_snapshot.insert("vbv_maxrate", config->getKey("vbv_maxrate"));
         entries_snapshot.insert("vbv_bufsize", config->getKey("vbv_bufsize"));
         entries_snapshot.insert("crf", config->getKey("crf"));
         entries_snapshot.insert("pools", config->getKey("pools"));

--- a/openstreamapp/ConfigurationDialog.h
+++ b/openstreamapp/ConfigurationDialog.h
@@ -94,8 +94,6 @@ private:
     QString POOLS_LABEL = QString("Pools");
 
     /*******Encoder params****************/
-    QLineEdit *x265vbvMaxRateFieldLineEdit;
-    QString x265vbvMaxRate_LABEL = QString("vbv_maxrate");
     QLineEdit *x265vbvBufsizeFieldLineEdit;
     QString x265vbvBufsize_LABEL = QString("vbv_bufsize");
     QLineEdit *crfLineEdit;

--- a/openstreamapp/h264cpuconfigurationdialog.cpp
+++ b/openstreamapp/h264cpuconfigurationdialog.cpp
@@ -57,9 +57,6 @@ h264CPUConfigurationDialog::h264CPUConfigurationDialog(QWidget *parent) :
     /*Pool threads*/
     ui->h264_cpu_pool_threads_combobox->addItems(this->POOL_THREADS_OPT_LIST);
 
-    /*VBV max rate*/
-    ui->h264_cpu_vbv_max_rate_value_combobox->addItems(VBV_MAX_RATE_LABEL_OPT_LIST);
-
     /*VBV_BUFSIZE*/
     ui->h264_cpu_vbv_bufsize_combobox->addItems(VBV_BUFSIZE_LABEL_OPT_LIST);
 
@@ -195,7 +192,6 @@ void h264CPUConfigurationDialog::setLoadedValues() {
         entries_snapshot.insert("crf", CRF_34);
     }
 
-
     /*VBV Bufsize*/
     if(config->getKey("vbv_bufsize") == VBV_BUFSIZE_1) {
         ui->h264_cpu_vbv_bufsize_combobox->setCurrentIndex(0);
@@ -213,25 +209,6 @@ void h264CPUConfigurationDialog::setLoadedValues() {
     else if(config->getKey("vbv_bufsize") ==  VBV_BUFSIZE_15) {
         ui->h264_cpu_vbv_bufsize_combobox->setCurrentIndex(3);
         entries_snapshot.insert("vbv_bufsize",  VBV_BUFSIZE_15);
-    }
-
-    /*vbv-maxrate*/
-    if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_10) {
-        ui->h264_cpu_vbv_max_rate_value_combobox->setCurrentIndex(0);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_10);
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_20) {
-        ui->h264_cpu_vbv_max_rate_value_combobox->setCurrentIndex(1);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_20);
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_30) {
-        ui->h264_cpu_vbv_max_rate_value_combobox->setCurrentIndex(2);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_30);
-
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_40) {
-        ui->h264_cpu_vbv_max_rate_value_combobox->setCurrentIndex(3);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_40);
     }
 
     /*FEC*/
@@ -302,20 +279,6 @@ void h264CPUConfigurationDialog::on_h264_cpu_ok_button_clicked()
     /*Pool threads*/
     QString selected_pool_threads = ui->h264_cpu_pool_threads_combobox->currentText();
     config->setEntry("pools", selected_pool_threads);
-    /*VBV maxrate value*/
-    QString selected_vbv_maxrate_label = ui->h264_cpu_vbv_max_rate_value_combobox->currentText();
-    if(selected_vbv_maxrate_label == VBV_MAX_RATE_10_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_10);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_20_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_20);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_30_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_30);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_40_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_40);
-    }
     /*VBV bufsize*/
     QString selected_vbv_bufsize_label = ui->h264_cpu_vbv_bufsize_combobox->currentText();
     if(selected_vbv_bufsize_label == VBV_BUFSIZE_1_LABEL) {
@@ -344,7 +307,6 @@ void h264CPUConfigurationDialog::on_h264_cpu_ok_button_clicked()
         entries_snapshot.value("system_priority") != config->getKey("system_priority") ||
         entries_snapshot.value("min_threads") != config->getKey("min_threads") ||
         entries_snapshot.value("pools") != config->getKey("pools") ||
-        entries_snapshot.value("vbv_maxrate") != config->getKey("vbv_maxrate") ||
         entries_snapshot.value("vbv_bufsize") != config->getKey("vbv_bufsize") ||
         entries_snapshot.value("crf") != config->getKey("crf") ||
         entries_snapshot.value("fec_percentage") != config->getKey("fec_percentage")
@@ -354,7 +316,6 @@ void h264CPUConfigurationDialog::on_h264_cpu_ok_button_clicked()
             entries_snapshot.insert("system_priority", config->getKey("system_priority"));
             entries_snapshot.insert("min_threads", config->getKey("min_threads"));
             entries_snapshot.insert("pools", config->getKey("pools"));
-            entries_snapshot.insert("vbv_maxrate", config->getKey("vbv_maxrate"));
             entries_snapshot.insert("vbv_bufsize", config->getKey("vbv_bufsize"));
             entries_snapshot.insert("fec_percentage", config->getKey("fec_percentage"));
             entries_snapshot.insert("crf", config->getKey("crf"));

--- a/openstreamapp/h264cpuconfigurationdialog.h
+++ b/openstreamapp/h264cpuconfigurationdialog.h
@@ -80,20 +80,6 @@ private:
                                                       << POOL_THREADS_6
                                                       << POOL_THREADS_8;
 
-    //VBV-MAX-Rate
-    QString VBV_MAX_RATE_10_LABEL = QString("10 Mbps");
-    QString VBV_MAX_RATE_10 = QString("10000");
-    QString VBV_MAX_RATE_20_LABEL = QString("20 Mbps");
-    QString VBV_MAX_RATE_20 = QString("20000");
-    QString VBV_MAX_RATE_30_LABEL = QString("30 Mbps");
-    QString VBV_MAX_RATE_30 = QString("30000");
-    QString VBV_MAX_RATE_40_LABEL = QString("40 Mbps");
-    QString VBV_MAX_RATE_40 = QString("40000");
-    QStringList VBV_MAX_RATE_LABEL_OPT_LIST = QStringList() << VBV_MAX_RATE_10_LABEL
-                                                            << VBV_MAX_RATE_20_LABEL
-                                                            << VBV_MAX_RATE_30_LABEL
-                                                            << VBV_MAX_RATE_40_LABEL;
-
     //VBV_BUFSIZE
     QString VBV_BUFSIZE_1_LABEL = QString("1 Mbps");
     QString VBV_BUFSIZE_1 = QString("1000");

--- a/openstreamapp/h264cpuconfigurationdialog.ui
+++ b/openstreamapp/h264cpuconfigurationdialog.ui
@@ -477,54 +477,6 @@ QComboBox QAbstractItemView {
     font:  &quot;Open Sans Semibold&quot;;
 }
 
-</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="QLabel" name="h264_cpu_vbv_max_rate_value_label">
-       <property name="toolTip">
-        <string>Sets the maximum rate the VBV buffer 
-should be assumed to refill at.</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QLabel {
-color: rgb(255, 255, 255);
-font:  &quot;Open Sans Semibold&quot;;
-font-size: 12px;
-}
-
-QToolTip {
-color: rgb(0, 0, 0);
-font:  &quot;Open Sans Semibold&quot;;
-font-size: 12px;
-}</string>
-       </property>
-       <property name="text">
-        <string>VBV Max-Rate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="h264_cpu_vbv_max_rate_value_combobox">
-       <property name="styleSheet">
-        <string notr="true">QComboBox {
-    border: 1px solid gray;
-    border-radius: 3px;
-    padding: 1px 18px 1px 3px;
-    min-width: 6em;
-    font:  &quot;Open Sans Semibold&quot;;
-    color: white;
-    background: #272640;
-}
-
 QComboBox:editable {
     background:white;
 }

--- a/openstreamapp/h265configurationdialog.cpp
+++ b/openstreamapp/h265configurationdialog.cpp
@@ -58,9 +58,6 @@ h265ConfigurationDialog::h265ConfigurationDialog(QWidget *parent) :
     /*Pool threads*/
     ui->h265_cpu_pool_threads_combobox->addItems(this->POOL_THREADS_OPT_LIST);
 
-    /*VBV max rate*/
-    ui->h265_cpu_vbv_max_rate_value_combobox->addItems(VBV_MAX_RATE_LABEL_OPT_LIST);
-
     /*VBV_BUFSIZE*/
     ui->h265_cpu_vbv_bufsize_combobox->addItems(VBV_BUFSIZE_LABEL_OPT_LIST);
 
@@ -224,25 +221,6 @@ void h265ConfigurationDialog::setLoadedValues() {
         entries_snapshot.insert("vbv_bufsize",  VBV_BUFSIZE_15);
     }
 
-    /*vbv-maxrate*/
-    if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_10) {
-        ui->h265_cpu_vbv_max_rate_value_combobox->setCurrentIndex(0);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_10);
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_20) {
-        ui->h265_cpu_vbv_max_rate_value_combobox->setCurrentIndex(1);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_20);
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_30) {
-        ui->h265_cpu_vbv_max_rate_value_combobox->setCurrentIndex(2);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_30);
-
-    }
-    else if(config->getKey("vbv_maxrate") == VBV_MAX_RATE_40) {
-        ui->h265_cpu_vbv_max_rate_value_combobox->setCurrentIndex(3);
-        entries_snapshot.insert("vbv_maxrate", VBV_MAX_RATE_40);
-    }
-
     /*FEC*/
     if(config->getKey("fec_percentage") == FEC_10) {
         ui->h265_cpu_fec_percentage_combobox->setCurrentIndex(0);
@@ -313,21 +291,6 @@ void h265ConfigurationDialog::on_h265_cpu_ok_button_clicked()
     /*Pool threads*/
     QString selected_pool_threads = ui->h265_cpu_pool_threads_combobox->currentText();
     config->setEntry("pools", selected_pool_threads);
-
-    /*VBV maxrate value*/
-    QString selected_vbv_maxrate_label = ui->h265_cpu_vbv_max_rate_value_combobox->currentText();
-    if(selected_vbv_maxrate_label == VBV_MAX_RATE_10_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_10);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_20_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_20);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_30_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_30);
-    }
-    else if(selected_vbv_maxrate_label == VBV_MAX_RATE_40_LABEL) {
-        config->setEntry("vbv_maxrate", VBV_MAX_RATE_40);
-    }
     /*VBV bufsize*/
     QString selected_vbv_bufsize_label = ui->h265_cpu_vbv_bufsize_combobox->currentText();
     if(selected_vbv_bufsize_label == VBV_BUFSIZE_1_LABEL) {
@@ -354,7 +317,6 @@ void h265ConfigurationDialog::on_h265_cpu_ok_button_clicked()
         entries_snapshot.value("system_priority") != config->getKey("system_priority") ||
         entries_snapshot.value("min_threads") != config->getKey("min_threads") ||
         entries_snapshot.value("pools") != config->getKey("pools") ||
-        entries_snapshot.value("vbv_maxrate") != config->getKey("vbv_maxrate") ||
         entries_snapshot.value("vbv_bufsize") != config->getKey("vbv_bufsize") ||
         entries_snapshot.value("crf") != config->getKey("crf") ||
         entries_snapshot.value("fec_percentage") != config->getKey("fec_percentage")
@@ -363,7 +325,6 @@ void h265ConfigurationDialog::on_h265_cpu_ok_button_clicked()
             entries_snapshot.insert("system_priority", config->getKey("system_priority"));
             entries_snapshot.insert("min_threads", config->getKey("min_threads"));
             entries_snapshot.insert("pools", config->getKey("pools"));
-            entries_snapshot.insert("vbv_maxrate", config->getKey("vbv_maxrate"));
             entries_snapshot.insert("vbv_bufsize", config->getKey("vbv_bufsize"));
             entries_snapshot.insert("fec_percentage", config->getKey("fec_percentage"));
             entries_snapshot.insert("crf", config->getKey("crf"));

--- a/openstreamapp/h265configurationdialog.h
+++ b/openstreamapp/h265configurationdialog.h
@@ -81,19 +81,6 @@ private:
                                                       << POOL_THREADS_6
                                                       << POOL_THREADS_8;
 
-    //VBV-MAX-Rate
-    QString VBV_MAX_RATE_10_LABEL = QString("10 Mbps");
-    QString VBV_MAX_RATE_10 = QString("10000");
-    QString VBV_MAX_RATE_20_LABEL = QString("20 Mbps");
-    QString VBV_MAX_RATE_20 = QString("20000");
-    QString VBV_MAX_RATE_30_LABEL = QString("30 Mbps");
-    QString VBV_MAX_RATE_30 = QString("30000");
-    QString VBV_MAX_RATE_40_LABEL = QString("40 Mbps");
-    QString VBV_MAX_RATE_40 = QString("40000");
-    QStringList VBV_MAX_RATE_LABEL_OPT_LIST = QStringList() << VBV_MAX_RATE_10_LABEL
-                                                            << VBV_MAX_RATE_20_LABEL
-                                                            << VBV_MAX_RATE_30_LABEL
-                                                            << VBV_MAX_RATE_40_LABEL;
     //VBV_BUFSIZE
     QString VBV_BUFSIZE_1_LABEL = QString("1 Mbps");
     QString VBV_BUFSIZE_1 = QString("1000");

--- a/openstreamapp/h265configurationdialog.ui
+++ b/openstreamapp/h265configurationdialog.ui
@@ -477,54 +477,6 @@ QComboBox QAbstractItemView {
     font:  &quot;Open Sans Semibold&quot;;
 }
 
-</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_11">
-     <item>
-      <widget class="QLabel" name="h265_cpu_vbv_max_rate_value_label">
-       <property name="toolTip">
-        <string>Sets the maximum rate the VBV buffer 
-should be assumed to refill at.</string>
-       </property>
-       <property name="styleSheet">
-        <string notr="true">QLabel {
-color: rgb(255, 255, 255);
-font:  &quot;Open Sans Semibold&quot;;
-font-size: 12px;
-}
-
-QToolTip {
-color: rgb(0, 0, 0);
-font:  &quot;Open Sans Semibold&quot;;
-font-size: 12px;
-}</string>
-       </property>
-       <property name="text">
-        <string>VBV Max-Rate</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="h265_cpu_vbv_max_rate_value_combobox">
-       <property name="styleSheet">
-        <string notr="true">QComboBox {
-    border: 1px solid gray;
-    border-radius: 3px;
-    padding: 1px 18px 1px 3px;
-    min-width: 6em;
-    font:  &quot;Open Sans Semibold&quot;;
-    color: white;
-    background: #272640;
-}
-
 QComboBox:editable {
     background:white;
 }

--- a/openstreamhost/openstreamhost/config.cpp
+++ b/openstreamhost/openstreamhost/config.cpp
@@ -90,7 +90,6 @@ video_t video {
   0, // qp
 
   0, // hevc_mode
-  1500, //vbv_maxrate
   3000, //vbv_bufsize
   4, //pools
   x265_default_params,
@@ -367,7 +366,6 @@ void apply_config(std::unordered_map<std::string, std::string> &&vars) {
   int_between_f(vars, "hevc_mode", video.hevc_mode, {
     0, 3
   });
-  int_f(vars, "vbv_maxrate", video.vbv_maxrate);
   int_f(vars, "vbv_bufsize", video.vbv_bufsize);
   int_f(vars, "pools", video.pools);
 
@@ -550,7 +548,6 @@ int parse(int argc, char *argv[]) {
 void update_x265_options() {
     video.x265_params = config::x265_default_params;
     video.x265_params = video.x265_params + ":vbv-bufsize=" + std::to_string(video.vbv_bufsize);
-    video.x265_params = video.x265_params + ":vbv-maxrate=" + std::to_string(video.vbv_maxrate);
 
     // Set pools and frame threads for multithreading control of cores.
     // https://trac.ffmpeg.org/ticket/3730?cversion=1
@@ -566,7 +563,6 @@ void update_x265_options() {
 void update_x264_options() {
     video.x264_params = config::x264_default_params;
     video.x264_params = video.x264_params + ":vbv-bufsize=" + std::to_string(video.vbv_bufsize);
-    video.x264_params = video.x264_params + ":vbv-maxrate=" + std::to_string(video.vbv_maxrate);
 
     //Specify threads for x264
     video.x264_params = video.x264_params + ":threads=" + std::to_string(video.min_threads);

--- a/openstreamhost/openstreamhost/config.h
+++ b/openstreamhost/openstreamhost/config.h
@@ -9,7 +9,7 @@
 namespace config {
 
 //https://forum.videohelp.com/threads/372625-ffmpeg-does-not-apply-parameters-with-libx265
-static const std::string x265_default_params = "info=0:keyint=-1:pmode=1:bitrate=0";
+static const std::string x265_default_params = "info=0:keyint=-1:pmode=1";
 static const std::string x264_default_params = "log-level=info";
 
 struct video_t {
@@ -18,7 +18,6 @@ struct video_t {
   int qp; // higher == more compression and less quality, ignored if crf != 0
 
   int hevc_mode;
-  int vbv_maxrate;
   int vbv_bufsize;
   // in x265 you control the thread limit with --pools config option and
   // with --frame-threads option. https://trac.ffmpeg.org/ticket/3730?cversion=1


### PR DESCRIPTION
Using vbv-maxrate will only cause the requested client bitrate to be
constrained.