### PR TITLE
Fix Stuck Keyboard Keys on Disconnection

### DIFF
--- a/openstreamhost/openstreamhost/input.cpp
+++ b/openstreamhost/openstreamhost/input.cpp
@@ -407,6 +407,13 @@ void passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&in
   task_pool.push(passthrough_helper, input, util::cmove(input_data));
 }
 
+void reset(){
+    for(auto& kp : key_press){
+      platf::keyboard(platf_input, kp.first & 0x00FF, true);
+      key_press[kp.first] = false;
+    }
+}
+
 void init() {
   platf_input = platf::input();
 }

--- a/openstreamhost/openstreamhost/input.h
+++ b/openstreamhost/openstreamhost/input.h
@@ -14,6 +14,7 @@ void print(void *input);
 void passthrough(std::shared_ptr<input_t> &input, std::vector<std::uint8_t> &&input_data);
 
 void init();
+void reset();
 
 std::shared_ptr<input_t> alloc();
 }

--- a/openstreamhost/openstreamhost/stream.cpp
+++ b/openstreamhost/openstreamhost/stream.cpp
@@ -894,7 +894,8 @@ state_e state(session_t &session) {
 
 void stop(session_t &session) {
   while_starting_do_nothing(session.state);
-
+  //Reset input on session stop to avoid stuck repeated keys
+  input::reset();
   auto expected = state_e::RUNNING;
   auto already_stopping = !session.state.compare_exchange_strong(expected, state_e::STOPPING);
   if(already_stopping) {


### PR DESCRIPTION
This patch should fix a bug that causes stuck keys when a client disconnects from the server.